### PR TITLE
Added artwork ID validation, category checks, and deletion function

### DIFF
--- a/contracts/clarity-art-registry.clar
+++ b/contracts/clarity-art-registry.clar
@@ -396,3 +396,53 @@
   (ok (is-eq (len name) u0))
 )
 
+
+;; Validate artwork ID
+(define-public (validate-artwork-id (artwork-id uint))
+  (ok (and (> artwork-id u0) (< artwork-id u1000000)))
+)
+
+;; Validate notes length
+(define-public (validate-notes-length (notes (string-ascii 128)))
+  (ok (and (> (len notes) u0) (<= (len notes) u128)))
+)
+
+;; Check if artwork has categories
+(define-public (has-categories (artwork-id uint))
+  (let 
+    (
+      (artwork-record (unwrap! (map-get? artwork-registry { artwork-id: artwork-id }) ERROR-ARTWORK-MISSING))
+    )
+    (ok (> (len (get categories artwork-record)) u0))
+  )
+)
+
+;; Get total categories for artwork
+(define-public (count-categories (artwork-id uint))
+  (let
+    (
+      (artwork-record (unwrap! (map-get? artwork-registry { artwork-id: artwork-id }) ERROR-ARTWORK-MISSING))
+    )
+    (ok (len (get categories artwork-record)))
+  )
+)
+
+;; ========================================================
+;; Deletion Functions
+;; ========================================================
+;; Remove artwork from registry
+(define-public (remove-artwork (artwork-id uint))
+  (let
+    (
+      (artwork-record (unwrap! (map-get? artwork-registry { artwork-id: artwork-id }) ERROR-ARTWORK-MISSING))
+    )
+    (asserts! (artwork-registered? artwork-id) ERROR-ARTWORK-MISSING)
+    (asserts! (is-eq (get artist artwork-record) tx-sender) ERROR-PERMISSION-DENIED)
+
+    ;; Delete artwork from registry
+    (map-delete artwork-registry { artwork-id: artwork-id })
+    (ok true)
+  )
+)
+
+


### PR DESCRIPTION
## Implement Artwork ID Validation, Category Checks, and Deletion  

**Notice**  
This update enhances the smart contract by adding validation functions for artwork IDs and notes, category checks, and the ability to delete artwork entries.  

**ntroduced**  
- **Validation Functions:**  
  - `validate-artwork-id` ensures artwork IDs fall within a valid range.  
  - `validate-notes-length` checks that artwork notes meet length requirements.  
- **Category Checks:**  
  - `has-categories` determines if an artwork has at least one category.  
  - `count-categories` retrieves the total number of categories assigned to an artwork.  
- **Deletion Functionality:**  
  - `remove-artwork` allows the artwork creator to delete their entry from the registry.  

**Conclusions**  
This update improves data integrity by enforcing stricter validation on artwork attributes while enabling creators to manage and remove their artwork when needed. Future improvements may include soft deletion with recovery options or admin-controlled removals.  
